### PR TITLE
Fixes first level without children / Adds placeholder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ $('level 1 select').cascadingSelect(options)
 |-------------|----------|---------|------------------------------------------------------------|
 | subSelects | string array | | jQuery selectors for sub selects  |
 | data | node array | | model of option tree |
+| placeholder | string | false | text of default option prepended to every select |
 
 #### Node format
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ $('level 1 select').cascadingSelect(options)
 |-------------|----------|---------|------------------------------------------------------------|
 | subSelects | string array | | jQuery selectors for sub selects  |
 | data | node array | | model of option tree |
-| placeholder | string | false | text of default option prepended to every select |
+| placeholder | string | false | text to show when no option selected |
+| placeholderWhenEmpty | string | false | text to show when no option available |
 
 #### Node format
 

--- a/index.html
+++ b/index.html
@@ -77,7 +77,8 @@
        $('#s1').cascadingSelect({
          subSelects: ['#s2', '#s3'],
          data: data,
-         placeholder: '-- Choose --'
+         placeholder: '-- Choose --',
+         placeholderWhenEmpty: '-'
        });
 
        $('#s4').cascadingSelect({

--- a/index.html
+++ b/index.html
@@ -72,11 +72,12 @@
            text: '3.3',
            children: ['3.3.1', '3.3.2', '3.3.3']
          }]
-       }];
+       }, '4'];
 
        $('#s1').cascadingSelect({
          subSelects: ['#s2', '#s3'],
-         data: data
+         data: data,
+         placeholder: '-- Choose --'
        });
 
        $('#s4').cascadingSelect({

--- a/index.js
+++ b/index.js
@@ -43,8 +43,10 @@
       // console.log('curNode', curNode);
       if (curNode && curNode.children && curNode.children.length) {
         entries = curNode.children;
+      } else if (settings.placeholder) {
+        entries = [{text: settings.placeholder, value: ''}];
       } else {
-        entries = [{text: settings.placeholder ? settings.placeholder : '', value: ''}];
+        entries = [];
       }
 
       $(nextSelect).
@@ -119,7 +121,7 @@
         }
       });
       if (settings.placeholder) {
-        normalizedData.unshift({text: '-- Normalized --', value: 'x', children: []});
+        normalizedData.unshift({text: settings.placeholder, value: '', children: []});
       }
       return normalizedData;
     }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@
 
   $.fn.cascadingSelect = function(options) {
     var defaults = {
-      placeholder: false
+      placeholder: false,
+      placeholderWhenEmpty: false
     };
     var settings = $.extend({
     }, defaults, options);
@@ -43,8 +44,8 @@
       // console.log('curNode', curNode);
       if (curNode && curNode.children && curNode.children.length) {
         entries = curNode.children;
-      } else if (settings.placeholder) {
-        entries = [{text: settings.placeholder, value: ''}];
+      } else if (settings.placeholderWhenEmpty) {
+        entries = [{text: settings.placeholderWhenEmpty, value: ''}];
       } else {
         entries = [];
       }

--- a/index.js
+++ b/index.js
@@ -11,10 +11,13 @@
   'use strict';
 
   $.fn.cascadingSelect = function(options) {
+    var defaults = {
+      placeholder: false
+    };
     var settings = $.extend({
-    }, options);
+    }, defaults, options);
 
-    var _data = normalizeData(settings.data);
+    var _data = normalizeData(settings);
 
     _data.nodeAtLevel = nodeAtLevel;
 
@@ -35,12 +38,18 @@
       var curLevel = _selects.indexOf(e.target);
       var curNode = _data.nodeAtLevel(curLevel);
       var nextSelect = _selects.slice(curLevel + 1)[0];
+      var entries;
 
       // console.log('curNode', curNode);
+      if (curNode && curNode.children && curNode.children.length) {
+        entries = curNode.children;
+      } else {
+        entries = [{text: settings.placeholder ? settings.placeholder : '', value: ''}];
+      }
 
       $(nextSelect).
         empty().
-        append(genOptions(curNode.children)).
+        append(genOptions(entries)).
         change();
     });
 
@@ -94,11 +103,11 @@
     }
   }
 
-  function normalizeData(data) {
-    return normalizeChildren(data);
+  function normalizeData(settings) {
+    return normalizeChildren(settings.data);
 
     function normalizeChildren(children) {
-      return children.map(function(c) {
+      var normalizedData = children.map(function(c) {
         if (typeof c === 'object') {
           return $.extend(
             { value: c.text }, c,
@@ -109,6 +118,10 @@
           return { text: text, value: text, children: [] };
         }
       });
+      if (settings.placeholder) {
+        normalizedData.unshift({text: '-- Normalized --', value: 'x', children: []});
+      }
+      return normalizedData;
     }
   }
 


### PR DESCRIPTION
Fix: If data tree has only first level without children / sublevel, the script breaks.
Added: Placeholder text option if you want to display default text before first selection and prevent the selects from being prefilled with the first option of each level.