### PR TITLE
Prevent TypeError: n is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,9 @@
 
     function nodeAtPath(path) {
       return path.reduce(function(n, i) {
-        return n.children[i];
+        if (typeof n !== 'undefined') {
+          return n.children[i];
+        }
       }, { children: _data });
     }
   }


### PR DESCRIPTION
Thanks for this useful library.

I have a 5 related dropdowns in my website.

After selecting option in the first dropdown I always get this error:
TypeError: n is undefined jquery.cascading-select.js:104:17 

I debugged this function:
```js
function nodeAtPath(path) {
	return path.reduce(function(n, i) {
		return n.children[i];
	}, { children: _data });
}
```

Content of path looks like this:
Array [ 1 ]
Array [ 1, 0 ]
Array(3) [ 1, 0, undefined ]
Array(4) [ 1, 0, undefined, undefined ]

TypeError happens on 4th iteration.

This simple type-check eliminates it.