### PR TITLE
Respect placeholderWhenEmpty option in preselect

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,17 +76,24 @@
         var s = $(this);
         var v = s.val();
 
-        if (v === null) {
-          return false;
-        }
+        var entries;
 
-        if (i >= 1 && nodeAtLevel(i - 1).children.length === 0) {
-          return false;
+        if (i === 0) {
+            entries = _data;
+        } else {
+            var curNode = nodeAtLevel(i - 1);
+            if (curNode && curNode.children && curNode.children.length) {
+                entries = curNode.children;
+            } else if (settings.placeholderWhenEmpty) {
+                entries = [{text: settings.placeholderWhenEmpty, value: ''}];
+            } else {
+                entries = [];
+            }
         }
 
         s.
           empty().
-          append(genOptions(i === 0 ? _data : nodeAtLevel(i - 1).children)).
+          append(genOptions(entries)).
           val(v);
       });
     }


### PR DESCRIPTION
Fixes #5

`placeholderWhenEmpty` option is not applied on initial rendering of dropdowns, it is only applied after selecting a value in the first dropdown.

I investigated this issue and pinned it down to `preselect()` function.
My application is rendering options of the first dropdown in HTML, so `init()` calls `preselect()` and `preselect()` knows nothing about `placeholderWhenEmpty`.

I updated `preselect()` to handle `placeholderWhenEmpty` in the same way as `change`.